### PR TITLE
importlib.resources.read_text is deprecated

### DIFF
--- a/mimetype_description/__init__.py
+++ b/mimetype_description/__init__.py
@@ -15,7 +15,7 @@ class MimeTypeDescription:
     def __init__(self):
         lang_attr = '{http://www.w3.org/XML/1998/namespace}lang'
         shared_mime_info = '{http://www.freedesktop.org/standards/shared-mime-info}'
-        data = pkg_resources.read_text(__package__, 'freedesktop.org.xml')
+        data = pkg_resources.files(__package__).joinpath('freedesktop.org.xml').read_text(encoding='utf-8')
         root = xml.etree.ElementTree.fromstring(data)
 
         for mime_type in root:

--- a/mimetype_description/__init__.py
+++ b/mimetype_description/__init__.py
@@ -18,7 +18,7 @@ class MimeTypeDescription:
         try:
             data = pkg_resources.files(__package__).joinpath('freedesktop.org.xml').read_text(encoding='utf-8')
         except AttributeError:
-            # pkg_resources.files et al doesn't exist because we're running python < 3.9.
+            # Try calling pkg_resources.read_text for compatibility with python < 3.9.
             data = pkg_resources.read_text(__package__, 'freedesktop.org.xml')
         root = xml.etree.ElementTree.fromstring(data)
 

--- a/mimetype_description/__init__.py
+++ b/mimetype_description/__init__.py
@@ -15,7 +15,11 @@ class MimeTypeDescription:
     def __init__(self):
         lang_attr = '{http://www.w3.org/XML/1998/namespace}lang'
         shared_mime_info = '{http://www.freedesktop.org/standards/shared-mime-info}'
-        data = pkg_resources.files(__package__).joinpath('freedesktop.org.xml').read_text(encoding='utf-8')
+        try:
+            data = pkg_resources.files(__package__).joinpath('freedesktop.org.xml').read_text(encoding='utf-8')
+        except AttributeError:
+            # pkg_resources.files et al doesn't exist because we're running python < 3.9.
+            data = pkg_resources.read_text(__package__, 'freedesktop.org.xml')
         root = xml.etree.ElementTree.fromstring(data)
 
         for mime_type in root:


### PR DESCRIPTION
Hello, and thanks for creating this project. My patch eliminates a deprecation warning on python 3.11. importlib.resources.read_text is going away, and per the python documentation the replacement is importlib.resources.files, which was introduced in python 3.9. My patch falls back to using read_text if files does not exist for compatibility with older versions of python. Thanks for considering!